### PR TITLE
Removed umbraco-marketplace tag from core project

### DIFF
--- a/src/Our.Umbraco.Honeypot.Core/Our.Umbraco.Honeypot.Core.csproj
+++ b/src/Our.Umbraco.Honeypot.Core/Our.Umbraco.Honeypot.Core.csproj
@@ -16,7 +16,7 @@
 		<Product>Our.Umbraco.Honeypot.Core</Product>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageTags>umbraco,spam,umbraco-marketplace</PackageTags>
+		<PackageTags>umbraco,spam</PackageTags>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Thanks for marking up this package for inclusion in the Umbraco marketplace.  I noticed though we were bringing in two entries - on for the installable component of the package, and one for this "core" project, which likely shouldn't be listed.  So I've suggested this update so we can just include the main package that developers will usually choose to install.